### PR TITLE
Add newline for NR output

### DIFF
--- a/lib/converge_funcs.py
+++ b/lib/converge_funcs.py
@@ -270,7 +270,7 @@ def get_placement_radii(rmin, rmax, RKstep, TOL, force_N, mp, MESA_file, masscut
 		r_print=(ru_mass_loop + rl)/2.0
 		r_nearest,rdex=find_nearest(fit_region_R,r_print)
 		u_local=fit_region_E[rdex]
-		outf.write("{} {} {} {}".format(force_N, r_print, Mshell_integral, u_local))
+		outf.write("{} {} {} {}\n".format(force_N, r_print, Mshell_integral, u_local))
 
 		RKtemp = RKstep	
 		Mshell_temp=Mshell_integral


### PR DESCRIPTION
I noticed a small bug when generating NR files. Although the file is generated without error, when running `run_conversion.py`, I get the following `TypeError`:
```
Traceback (most recent call last):
  File "./run_conversion.py", line 211, in <module>
    mn.get_IC(MESA_file, masscut, in_file, out_file, mp,\
  File ".../MESA2HYDRO-1.1.2-py3.8-linux-x86_64.egg/MESA2HYDRO/lib/mainlib.py", line 181, in get_IC
    for i in range(len(N)):
TypeError: object of type 'numpy.float64' has no len()
```
`loadtxt` in line 167 of `mainlib.py` expects a column for N, but only receives a single line since `converge_funcs.py` doesn't create a newline. 

All I did was add `\n` and that solved the error on my end!